### PR TITLE
Reject adding duplicates to TaskList

### DIFF
--- a/src/main/java/duke/Duke.java
+++ b/src/main/java/duke/Duke.java
@@ -36,8 +36,12 @@ public class Duke {
      * Replace this stub with your completed method.
      */
     public void respond(String input) {
-        Command command = Parser.parse(input);
-        command.execute(taskList, ui);
+        try {
+            Command command = Parser.parse(input);
+            command.execute(taskList, ui);
+        } catch (Exception ex) {
+            ui.displayError(ex.getMessage());
+        }
     }
 
     public void save() {

--- a/src/main/java/duke/TaskList.java
+++ b/src/main/java/duke/TaskList.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 /**
- * Represents a list of any number of Tasks, including zero.
+ * Represents a list of any number of Tasks with different names, including zero.
  */
 public class TaskList {
     public static final String DUPLICATE_TASK_MESSAGE_SUFFIX = " already exists in the TaskList";
@@ -41,8 +41,7 @@ public class TaskList {
     }
 
     /**
-     * Finds a Task with the same name as a supplied String.
-     * If multiple are present, the first one is returned.
+     * Finds the Task with the same name as a supplied String, if any.
      * @param taskName The name of the Task to find
      * @return A Task with the same name, or <code>null</code> if none was found.
      */
@@ -57,9 +56,9 @@ public class TaskList {
 
     /**
      * Finds all Tasks containing a supplied String.
-     * If multiple are present, the first one is returned.
      * @param keyword The name of the Task to find
-     * @return A Task with the same name, or <code>null</code> if none was found.
+     * @return A TaskList containing all Tasks from this list
+     * with <code>keyword</code> as a substring
      */
     public TaskList match(String keyword) {
         List<Task> matchingTasks = new ArrayList<>();
@@ -74,8 +73,7 @@ public class TaskList {
 
 
     /**
-     * Removes a Task with the same name as a supplied String
-     * If multiple are present, the first is deleted
+     * Removes the Task with the same name as a supplied String, if any.
      * @param taskName The name of the Task to be deleted
      * @return The deleted Task, or <code>null</code> if none were deleted
      */

--- a/src/main/java/duke/TaskList.java
+++ b/src/main/java/duke/TaskList.java
@@ -8,6 +8,7 @@ import java.util.stream.Collectors;
  * Represents a list of any number of Tasks, including zero.
  */
 public class TaskList {
+    public static final String DUPLICATE_TASK_MESSAGE_SUFFIX = " already exists in the TaskList";
     private List<Task> taskList;
 
     /**
@@ -33,6 +34,9 @@ public class TaskList {
      * @param task The Task to be added to this TaskList
      */
     public void add(Task task) {
+        if (find(task.getName()) != null) {
+            throw new IllegalArgumentException(task.getName() + DUPLICATE_TASK_MESSAGE_SUFFIX);
+        }
         taskList.add(task);
     }
 


### PR DESCRIPTION
TaskList now throws IllegalArgumentException if trying to add a task with the same name as an existing task